### PR TITLE
Add new relic script tag to head, not body

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ window.NREUM||(NREUM={}),__nr_require=function(t,e,n){function r(n){if(!e[n]){va
             { type: 'text/javascript' },
             this.newrelicstring,
           );
-          data.bodyTags.push(newRelicScriptTag);
+          data.headTags.push(newRelicScriptTag);
         }
       );
     });


### PR DESCRIPTION
@victorrodrigues - First off, thanks for the plugin! 
Following https://docs.newrelic.com/docs/browser/new-relic-browser/installation/install-new-relic-browser-agent, looks like the `newRelicScriptTag` needs to be added to `headTags` - let me know what you think.